### PR TITLE
completed init_1 script

### DIFF
--- a/airflow/dags/init_1_spark_Dataproc_dag.py
+++ b/airflow/dags/init_1_spark_Dataproc_dag.py
@@ -24,7 +24,6 @@ STAGING_BUCKET = os.environ.get("DATAPROC_STAGING_BUCKET", "my-dataproc-staging"
 # ---- Dataproc cluster config (single-node, staging bucket only)
 CLUSTER_CONFIG = {
     "project_id": PROJECT_ID,
-    "cluster_name": CLUSTER_NAME,
     "config": {
         "config_bucket": STAGING_BUCKET,   # staging bucket for temp + logs
         "gce_cluster_config": {


### PR DESCRIPTION
1) This script checks if the init_0_ingestion_to_gcs_dag is completed, then it starts
2) Creates temporary DataProc clusters for Spark jobs with the correct staging buckets
The cluster name is extras-data-transformer
3) Runs Spark Job:  init-data-transformation.py which processes extra jurney file like London transport 2021.
4) Delete Clusters even if Job fails
5) Mark start and end of pipeline using EmptyOperator